### PR TITLE
Insert log-part items altogether

### DIFF
--- a/Src/AdvancedLogViewer/UI/MainForm.cs
+++ b/Src/AdvancedLogViewer/UI/MainForm.cs
@@ -850,21 +850,8 @@ namespace AdvancedLogViewer.UI
 
                             //Load file names of other parts of the log
                             this.openOtherPartsButton.DropDown.Items.Clear();
-                            foreach (string fileName in this.logParser.AllLogPartsFileNames)
-                            {
-                                string onlyFileName = Path.GetFileName(fileName);
-
-                                ToolStripMenuItem openItem = new ToolStripMenuItem(onlyFileName);
-                                openItem.Click += new EventHandler(openOtherLogsItem_Click);
-                                openItem.Tag = fileName;
-                                this.openOtherPartsButton.DropDown.Items.Add(openItem);
-
-                                if (fileName.Equals(this.logParser.LogFileName))
-                                {
-                                    openItem.Enabled = false;
-                                    openItem.Font = new Font(openItem.Font, FontStyle.Bold);
-                                }
-                            }
+                            var items = GetOtherPartNamesOfLog().ToArray();
+                            this.openOtherPartsButton.DropDown.Items.AddRange(items);
 
                             //Load Log Adjuster
                             this.LoadLogAdjuster();
@@ -1069,6 +1056,26 @@ namespace AdvancedLogViewer.UI
                         }
                     }
                 }
+            }
+        }
+
+        private IEnumerable<ToolStripItem> GetOtherPartNamesOfLog()
+        {
+            foreach (string fileName in logParser.AllLogPartsFileNames)
+            {
+                string onlyFileName = Path.GetFileName(fileName);
+
+                var openItem = new ToolStripMenuItem(onlyFileName);
+                openItem.Click += new EventHandler(openOtherLogsItem_Click);
+                openItem.Tag = fileName;
+
+                if (fileName.Equals(logParser.LogFileName))
+                {
+                    openItem.Enabled = false;
+                    openItem.Font = new Font(openItem.Font, FontStyle.Bold);
+                }
+
+                yield return openItem;
             }
         }
 


### PR DESCRIPTION
When opening a log with many parts (e.g. LogFiles\Logs_Agent\APM\SolarWinds.APM.Probes_[xxxxx].log) all the parts are loaded for the 'Open another log part' icon.
For around 400 items this could take about 6 seconds.
Instead of tampering with the calculation of what belongs to "AllLogPartsFileNames", this PR speeds up the loading time.

The most expensive operation was adding the ToolStripItem one by one. Now they are being added in one batch, which speeds the loading of the logs dramatically.